### PR TITLE
adjust remote eval functions for newest lem

### DIFF
--- a/lem/remote-eval.lisp
+++ b/lem/remote-eval.lisp
@@ -10,7 +10,7 @@
 
 (defclass server (trivial-ws:server)
   ((event-queue
-    :initform (lem::make-event-queue)
+    :initform (lem-core::make-event-queue)
     :reader server-event-queue)
    (handler
     :initform nil
@@ -81,7 +81,7 @@
                  (return))
                 ((trivial-ws:clients *server*)
                  (js-eval form :use-return-value t)
-                 (write-line (lem::dequeue-event nil (server-event-queue *server*))))
+                 (write-line (lem-core::dequeue-event nil (server-event-queue *server*))))
                 (t
                  (uiop:println "No connection" *error-output*))))))))
 

--- a/lem/valtan-mode.lisp
+++ b/lem/valtan-mode.lisp
@@ -13,7 +13,7 @@
 (define-key *valtan-mode-keymap* "C-M-x" 'valtan-eval-defun)
 
 (defun current-valtan-package ()
-  (lem-lisp-mode::update-buffer-package)
+  (lem-lisp-mode/internal::update-buffer-package)
   (or (ignore-errors
         (find-package
          (read-from-string
@@ -28,7 +28,7 @@
   (with-point ((start (current-point))
                (end (current-point)))
     (form-offset start -1)
-    (lem-lisp-mode::highlight-evaluation-region start end)
+    (lem-lisp-mode/internal::highlight-evaluation-region start end)
     (eval-string (points-to-string start end))))
 
 (define-command valtan-eval-defun () ()
@@ -37,5 +37,5 @@
     (with-point ((start point)
                  (end point))
       (scan-lists end 1 0)
-      (lem-lisp-mode::highlight-evaluation-region start end)
+      (lem-lisp-mode/internal::highlight-evaluation-region start end)
       (eval-string (points-to-string start end)))))


### PR DESCRIPTION
I installed the newest Lem and I found that the remote-eval stopped working because some packages were renamed.
This should fix all of it though I think! I got the repl working with the browser locally again. Let me know if anything looks off.