### PR TITLE
Match Makefile in Readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 LISP ?= sbcl
 PROGNAME=valtan
 
+all: build
+
 deps:
 	git submodule update --init --recursive
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ From source:
 $ git clone https://github.com/cxxxr/valtan ~/common-lisp/valtan
 $ cd ~/common-lisp/valtan
 $ make build
-$ sudo make install
+$ ./valtan
 ```
 
 ## Demo


### PR DESCRIPTION
Remove the install make target from readme, and allow `make` instead of `make build`